### PR TITLE
Document that root access may be necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Then, either in a development environment or as part of your <abbr title="Contin
 $ ./vendor/bin/install-runkit.sh
 ```
 
+> **Note:** If you receive permission issues, you may need to run the command above prefixed with `sudo`.
+
 If you wish to install a specific version of Runkit7, you may pass the version number to the script as an argument:
 
 ```sh


### PR DESCRIPTION
Depending on the environment, a regular user may not have access to install PECL packages directly. This commit ensures that people are warned that they might need to run the script with `sudo`.

Fixes #3.