### PR TITLE
Automatically create runkit.ini files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,15 +1,16 @@
 # This file is for unifying the coding style for different editors and IDEs
 # editorconfig.org
 
-# PHP PSR-2 Coding Standards
-# http://www.php-fig.org/psr/psr-2/
-
 root = true
 
-[*.php]
+[*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ install:
 
 script:
   - ./vendor/bin/phpunit
+  - shellcheck bin/*.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 dist: trusty
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ php:
 install:
   - composer install --prefer-dist
 
+before_script:
+  - sudo mkdir -p "/etc/php/${TRAVIS_PHP_VERSION}/mods-available"
+
 script:
   - ./vendor/bin/phpunit
   - shellcheck bin/*.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+* Attempt to automatically create `runkit.ini` files upon installation ([#1]).
 * Document that root access might be necessary to run the installer ([#3]).
 * Include [Shellcheck](https://www.shellcheck.net/) as part of the continuous integration process.
 
@@ -16,4 +17,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]: https://github.com/stevegrunwell/runkit7-installer/compare/master...develop
 [1.0.0]: https://github.com/stevegrunwell/runkit7-installer/releases/tag/v1.0.0
+[#1]: https://github.com/stevegrunwell/runkit7-installer/issues/1
 [#3]: https://github.com/stevegrunwell/runkit7-installer/issues/3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 * Attempt to automatically create `runkit.ini` files upon installation ([#1]).
+* Add a `name` attribute to the `<testsuite>` node, fixing some Travis build errors ([#2]).
 * Document that root access might be necessary to run the installer ([#3]).
 * Include [Shellcheck](https://www.shellcheck.net/) as part of the continuous integration process.
 
@@ -18,4 +19,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [Unreleased]: https://github.com/stevegrunwell/runkit7-installer/compare/master...develop
 [1.0.0]: https://github.com/stevegrunwell/runkit7-installer/releases/tag/v1.0.0
 [#1]: https://github.com/stevegrunwell/runkit7-installer/issues/1
+[#2]: https://github.com/stevegrunwell/runkit7-installer/issues/2
 [#3]: https://github.com/stevegrunwell/runkit7-installer/issues/3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 * Document that root access might be necessary to run the installer ([#3]).
+* Include [Shellcheck](https://www.shellcheck.net/) as part of the continuous integration process.
 
 ## [1.0.0] - 2018-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+* Document that root access might be necessary to run the installer ([#3]).
+
+## [1.0.0] - 2018-03-29
+
+* Initial public release.
+
+[Unreleased]: https://github.com/stevegrunwell/runkit7-installer/compare/master...develop
+[1.0.0]: https://github.com/stevegrunwell/runkit7-installer/releases/tag/v1.0.0
+[#3]: https://github.com/stevegrunwell/runkit7-installer/issues/3

--- a/bin/install-runkit.sh
+++ b/bin/install-runkit.sh
@@ -34,7 +34,8 @@ download "https://github.com/runkit7/runkit7/releases/download/${RUNKIT_VERSION}
     && rm "$DOWNLOAD_FILENAME"
 
 # Create runkit.ini files for each version of PHP.
-for DIR in /etc/php/*/mods-available; do
+MODS=$(find /etc/php/ -name "*/mods-available" -type d)
+for DIR in $MODS; do
     if [ ! -f "$DIR/runkit.ini" ]; then
         echo "extension=runkit.so" | sudo tee "$DIR/runkit.ini" > /dev/null \
             && echo "Created ${DIR}/runkit.ini"

--- a/bin/install-runkit.sh
+++ b/bin/install-runkit.sh
@@ -43,6 +43,6 @@ for DIR in $MODS; do
 done
 
 # Attempt to enable the Runkit PHP module.
-if [ ! "$(command -v phpenmod)" ]; then
+if [ "$(command -v phpenmod)" ]; then
     sudo phpenmod runkit && echo "\\033[0;32mRunkit7 has been installed and activated!\\033[0;0m"
 fi

--- a/bin/install-runkit.sh
+++ b/bin/install-runkit.sh
@@ -34,7 +34,7 @@ download "https://github.com/runkit7/runkit7/releases/download/${RUNKIT_VERSION}
     && rm "$DOWNLOAD_FILENAME"
 
 # Create runkit.ini files for each version of PHP.
-MODS=$(find /etc/php/ -name "*/mods-available" -type d)
+MODS=$(find /etc/php/ -name "mods-available" -type d)
 for DIR in $MODS; do
     if [ ! -f "$DIR/runkit.ini" ]; then
         echo "extension=runkit.so" | sudo tee "$DIR/runkit.ini" > /dev/null \

--- a/bin/install-runkit.sh
+++ b/bin/install-runkit.sh
@@ -42,5 +42,7 @@ for DIR in $MODS; do
     fi
 done
 
-# Enable the Redis PHP module.
-sudo phpenmod runkit && echo "\\033[0;32mRunkit7 has been installed and activated!\\033[0;0m"
+# Attempt to enable the Runkit PHP module.
+if [ ! "$(command -v phpenmod)" ]; then
+    sudo phpenmod runkit && echo "\\033[0;32mRunkit7 has been installed and activated!\\033[0;0m"
+fi

--- a/bin/install-runkit.sh
+++ b/bin/install-runkit.sh
@@ -30,7 +30,7 @@ fi
 # Download and install Runkit7.
 echo "\\033[0;33mInstalling Runkit7...\\033[0;m"
 download "https://github.com/runkit7/runkit7/releases/download/${RUNKIT_VERSION}/runkit-${RUNKIT_VERSION}.tgz" "$DOWNLOAD_FILENAME" \
-    && sudo pecl install "$DOWNLOAD_FILENAME" \
+    && pecl install "$DOWNLOAD_FILENAME" \
     && rm "$DOWNLOAD_FILENAME"
 
 # Create runkit.ini files for each version of PHP.

--- a/bin/install-runkit.sh
+++ b/bin/install-runkit.sh
@@ -30,5 +30,16 @@ fi
 # Download and install Runkit7.
 echo "\\033[0;33mInstalling Runkit7...\\033[0;m"
 download "https://github.com/runkit7/runkit7/releases/download/${RUNKIT_VERSION}/runkit-${RUNKIT_VERSION}.tgz" "$DOWNLOAD_FILENAME" \
-    && pecl install "$DOWNLOAD_FILENAME" \
+    && sudo pecl install "$DOWNLOAD_FILENAME" \
     && rm "$DOWNLOAD_FILENAME"
+
+# Create runkit.ini files for each version of PHP.
+for DIR in /etc/php/*/mods-available; do
+    if [ ! -f "$DIR/runkit.ini" ]; then
+        echo "extension=runkit.so" | sudo tee "$DIR/runkit.ini" > /dev/null \
+            && echo "Created ${DIR}/runkit.ini"
+    fi
+done
+
+# Enable the Redis PHP module.
+sudo phpenmod runkit && echo "\\033[0;32mRunkit7 has been installed and activated!\\033[0;0m"

--- a/tests/InstallTest.php
+++ b/tests/InstallTest.php
@@ -9,43 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 class InstallTest extends TestCase
 {
-    private static $createdDirectories = [];
-
-    /**
-     * Get an array of all PHP versions we want to use for testing configuration.
-     *
-     * @return array
-     */
-    public static function getTestedVersions(): array
-    {
-        return [
-            '7.0',
-            '7.1',
-            '7.2',
-            '50.0', // Something very unlikely to exist.
-        ];
-    }
-
-    /**
-     * If the local filesystem doesn't have them, create mods-available directories.
-     *
-     * @beforeClass
-     */
-    public static function createModsAvailable()
-    {
-        foreach (self::getTestedVersions() as $version) {
-            if (mkdir('/etc/php/' . $version . '/mods-available', 0777, true)) {
-                self::$createdDirectories[] = '/etc/php/' . $version;
-            }
-        }
-    }
-
     public function testInstallsRunkit()
     {
         $this->assertFalse(
             extension_loaded('runkit'),
             'Expected the Runkit extension to not yet be loaded.'
         );
+
+        $version = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
 
         exec(dirname(__DIR__) . '/bin/install-runkit.sh', $output, $exitCode);
 
@@ -54,13 +25,10 @@ class InstallTest extends TestCase
             (bool) preg_match('/^runkit\s/m', shell_exec('pecl list')),
             'The Runkit extension should have been loaded.'
         );
-
-        foreach (self::getTestedVersions() as $version) {
-            $this->assertTrue(
-                file_exists('/etc/php/' . $version . '/mods-available/runkit.ini'),
-                'Expected a runkit.ini file to be created for PHP ' . $version
-            );
-        }
+        $this->assertTrue(
+            file_exists('/etc/php/' . $version . '/mods-available/runkit.ini'),
+            'Expected a runkit.ini file to be created for PHP ' . $version . '.'
+        );
     }
 
     /**
@@ -73,19 +41,6 @@ class InstallTest extends TestCase
         $this->assertTrue(function_exists('runkit_constant_remove'));
         $this->assertTrue(function_exists('runkit_function_add'));
         $this->assertTrue(function_exists('runkit_function_remove'));
-    }
-
-    /**
-     * Remove directories that were only created for tests.
-     *
-     * @afterClass
-     */
-    public static function removeModsAvailable()
-    {
-        foreach (self::$createdDirectories as $dir) {
-            unlink($dir . '/runkit.ini');
-            rmdir($dir);
-        }
     }
 
     /**


### PR DESCRIPTION
This PR attempts to automatically create `runkit.ini` files in `/etc/php/*/mods-available` directories, which seems to at least be the Ubuntu standard (not sure if other distros move these around or not; if so, I'd love to know about them!). Fixes #1.

Additionally, [Shellcheck](https://www.shellcheck.net/) has been added as a build dependency.