### PR TITLE
Add PHP 7.3 and 'nightly' to the Travis testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ php:
   - 7.1
   - 7.0
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+
 install:
   - composer install --prefer-dist
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ notifications:
   email: never
 
 php:
+  - nightly
+  - 7.3
   - 7.2
   - 7.1
   - 7.0

--- a/bin/install-runkit.sh
+++ b/bin/install-runkit.sh
@@ -3,7 +3,7 @@
 # Automate the installation of Runkit7 in development and testing environments.
 
 # Enable users to set an explicit version.
-[ "$1" ] && RUNKIT_VERSION=$1 || RUNKIT_VERSION="1.0.5b1"
+[ "$1" ] && RUNKIT_VERSION=$1 || RUNKIT_VERSION="1.0.9"
 
 DOWNLOAD_FILENAME="runkit-${RUNKIT_VERSION}.tgz"
 


### PR DESCRIPTION
This PR adds PHP 7.3 support by [upgrading Runkit 7 to 1.0.9](https://github.com/runkit7/runkit7/releases/tag/1.0.9) and adjusting the `.travis.yml` file accordingly.